### PR TITLE
refactor docker and gradle files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM mcr.microsoft.com/openjdk/jdk:17-ubuntu as dev
 ENV TZ=America/New_York
 RUN apt update
-RUN apt -y install wget git unzip
+RUN apt -y install wget unzip
+
 RUN wget https://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 RUN mkdir /opt/gradle
 RUN unzip -d /opt/gradle gradle-7.3.1-bin.zip
 ENV PATH=$PATH:/opt/gradle/gradle-7.3.1/bin
+
+RUN mkdir /cc
+WORKDIR /cc
+COPY . /cc
+RUN gradle build

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
 }
-//Dependency Management
+
 repositories {
     mavenCentral()
 }
@@ -22,53 +22,15 @@ jar {
     duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
-    manifest {
-
-        attributes 'Main-Class': 'usace.cc.plugin.Test'
-    }
+    // manifest {
+    //     attributes 'Main-Class': 'usace.cc.plugin.Test'
+    // }
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }
-sourceSets {
-    main {
-        java {
-            srcDirs= ["src/main/java"]
-        }
-        resources {
-            srcDirs= ["src/main/resources"]
-        }
-    }
-}
-publishing {
-    repositories {
-        maven {
-            // Choose whatever name you want
-            name = "GitHubPackages"
-            // The url of the repository, where the artifacts will be published
-            url = "https://maven.pkg.github.com/USACE/cc-java-sdk"
-            credentials {
-                // The credentials (described in the next section)
-                username = System.getenv("USERNAME")
-                password = System.getenv("TOKEN")
-            }
-        }
-    }
-    publications {
-        gpr(MavenPublication) {
-            from(components.java)
-            // Fixes the error with dynamic versions when using Spring Boot
-            versionMapping {
-                usage('java-api') {
-                    fromResolutionOf('runtimeClasspath')
-                }
-                usage('java-runtime') {
-                    fromResolutionResult()
-                }
-            }
-        }
-    }
 
+publishing {
     group 'mil.army.usace.hec'
     version '0.0.50'
 }

--- a/src/main/java/usace/cc/plugin/CcStoreS3.java
+++ b/src/main/java/usace/cc/plugin/CcStoreS3.java
@@ -7,8 +7,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-// Add for local dev
-import java.nio.file.Files;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
@@ -174,23 +172,12 @@ public class CcStoreS3 implements CcStore {
     // TODO: Remove after testing
     @Override
     public Payload GetPayload() throws Exception{ //throws AmazonS3Exception {
-        // String filepath = root + "/" + manifestId + "/" + Constants.PayloadFileName;
-        // try{
-        //     byte[] body = DownloadBytesFromS3(filepath);
-        //     return ReadJsonModelPayloadFromBytes(body);
-        // } catch (Exception e){
-        //     throw new AmazonS3Exception(e.toString());
-        // }
-
-        //Change to read local payload
-        File file = new File("build/resources/main/payload-original");
-        System.out.println(file.toPath());
-        try {
-            byte[] body = Files.readAllBytes(file.toPath());
+        String filepath = root + "/" + manifestId + "/" + Constants.PayloadFileName;
+        try{
+            byte[] body = DownloadBytesFromS3(filepath);
             return ReadJsonModelPayloadFromBytes(body);
-        } catch (Exception e) {
-            System.out.println("Failure!!");
-            throw e;
+        } catch (Exception e){
+            throw new AmazonS3Exception(e.toString());
         }
     }
     private byte[] DownloadBytesFromS3(String key) throws Exception{


### PR DESCRIPTION
This PR simplifies the gradle build processs

- removes publishing to `https://maven.pkg.github.com/USACE/cc-java-sdk`
- run build gradle in the container